### PR TITLE
Restart the service every 5 minutes indefinitely

### DIFF
--- a/host/worker-queue.service
+++ b/host/worker-queue.service
@@ -2,9 +2,12 @@
 Description=Valohai Worker Queue
 After=docker.service
 Requires=docker.service
+StartLimitIntervalSec=0
+StartLimitBurst=3
 
 [Service]
 Restart=always
+RestartSec=300
 ExecStart=/usr/bin/docker run --rm \
                               --name %n \
                               --network host \


### PR DESCRIPTION
We start the worker-queue service on all new environments as soon as the VM is created. If the vqueue.net address is not activated yet it will fail to start, and eventually, stop trying to restart.

Updating the policy to restart every 5 minutes and try for ever.