### PR TITLE
Custom Redis port

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Publish: `./publish.sh`
 
 > :warning: The worker queue host machine needs to have port 80 open to the internet and port 63790 open to Valohai (roi) and workers (peon)!
 
-Installing the worker queue on a machine is as easy as running: `curl https://raw.githubusercontent.com/valohai/worker-queue/main/host/setup.sh | sudo QUEUE_ADDRESS=your-queue-address-here REDIS_PASSWORD=your-redis-password-here bash`
+Installing the worker queue on a machine is as easy as running: `curl https://raw.githubusercontent.com/valohai/worker-queue/main/host/setup.sh | sudo QUEUE_ADDRESS=your-queue-address-here REDIS_PASSWORD=your-redis-password-here REDIS_PORT=redis-tls-port bash`
 
 This installs Docker and creates a systemd service that runs the worker queue with the given parameters.
 

--- a/docker/redis/redis.conf
+++ b/docker/redis/redis.conf
@@ -135,7 +135,7 @@ tcp-keepalive 300
 # default port, use:
 #
 # port 0
-tls-port 63790
+# tls-port 63790
 
 # Configure a X.509 certificate and private key to use for authenticating the
 # server to connected clients, masters or cluster peers.  These files should be

--- a/docker/run_worker_queue.sh
+++ b/docker/run_worker_queue.sh
@@ -23,5 +23,6 @@ fi
 
 sed -i "s|# requirepass foobared|requirepass $REDIS_PASSWORD|" /etc/redis/redis.conf
 sed -i "s|FILL_ADDRESS|$QUEUE_ADDRESS|" /etc/redis/redis.conf
+sed -i "s|# tls-port 63790|tls-port $REDIS_PORT|" /etc/redis/redis.conf
 
 exec redis-server /etc/redis/redis.conf

--- a/host/setup.sh
+++ b/host/setup.sh
@@ -10,6 +10,12 @@ if [ -z "$REDIS_PASSWORD" ]; then
     exit 1
 fi
 
+# Be explicit about the Redis TLS port we want
+if [ -z "$REDIS_PORT" ]; then
+    # Default to 63790
+    REDIS_PORT=63790
+fi
+
 # Make bash more strict about errors
 set -euo pipefail
 
@@ -57,6 +63,7 @@ ExecStart=/usr/bin/docker run --rm \
                               --mount source=redis,target=/var/lib/redis \
                               -e QUEUE_ADDRESS=$QUEUE_ADDRESS \
                               -e REDIS_PASSWORD=$REDIS_PASSWORD \
+                              -e REDIS_PORT=$REDIS_PORT \
                               $DOCKER_IMAGE
 ExecStop=/usr/bin/docker stop %n
 

--- a/host/worker-queue.service
+++ b/host/worker-queue.service
@@ -15,6 +15,7 @@ ExecStart=/usr/bin/docker run --rm \
                               --mount source=redis,target=/var/lib/redis \
                               -e QUEUE_ADDRESS=$QUEUE_ADDRESS \
                               -e REDIS_PASSWORD=$REDIS_PASSWORD \
+                              -e REDIS_PORT=$REDIS_PORT \
                               valohai/worker-queue:latest
 ExecStop=/usr/bin/docker stop %n
 


### PR DESCRIPTION
Fixes #8 

Rewrite given tls-port into redis.config from envvars. Make it default to 63790.